### PR TITLE
Add a swapPVs function

### DIFF
--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -849,10 +849,10 @@ func resetReclaimPolicy(ctx context.Context, w *log.Logger, clientset k8sclient.
 	}, func(volume *corev1.PersistentVolume) bool {
 		if reclaim != nil {
 			return volume.Spec.PersistentVolumeReclaimPolicy == *reclaim
-		} else {
-			if annotationVal, ok := volume.Annotations[desiredReclaimAnnotation]; ok {
-				return volume.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimPolicy(annotationVal)
-			}
+		}
+
+		if annotationVal, ok := volume.Annotations[desiredReclaimAnnotation]; ok {
+			return volume.Spec.PersistentVolumeReclaimPolicy == corev1.PersistentVolumeReclaimPolicy(annotationVal)
 		}
 
 		return true

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -722,3 +722,183 @@ func Test_createMigrationPod(t *testing.T) {
 		})
 	}
 }
+
+func Test_swapPVs(t *testing.T) {
+	sourceScName := "sourceScName"
+	destScName := "destScName"
+	tests := []struct {
+		name          string
+		resources     []runtime.Object
+		wantResources []*metav1.APIResourceList
+		ns            string
+		pvcName       string
+		wantErr       bool
+	}{
+		{
+			name:    "swap one PVC",
+			ns:      "testns",
+			pvcName: "sourcepvc",
+			resources: []runtime.Object{
+				// two PVCs
+				&corev1.PersistentVolumeClaim{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "PersistentVolumeClaim",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sourcepvc",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							"testannotation": "sourcepvc",
+						},
+						Labels: map[string]string{
+							"testlabel": "sourcepvc",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteMany,
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+						StorageClassName: &sourceScName,
+						VolumeName:       "source-pv",
+					},
+					Status: corev1.PersistentVolumeClaimStatus{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteMany,
+						},
+						Capacity: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+						Phase: corev1.ClaimBound,
+					},
+				},
+				&corev1.PersistentVolumeClaim{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "PersistentVolumeClaim",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sourcepvc-pvcmigrate",
+						Namespace: "testns",
+						Annotations: map[string]string{
+							"testannotation": "sourcepvc-pvcmigrate",
+						},
+						Labels: map[string]string{
+							"testlabel": "sourcepvc-pvcmigrate",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+						StorageClassName: &destScName,
+						VolumeName:       "dest-pv",
+					},
+					Status: corev1.PersistentVolumeClaimStatus{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Capacity: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+						Phase: corev1.ClaimBound,
+					},
+				},
+				// two PVs
+				&corev1.PersistentVolume{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "PersistentVolume",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "source-pv",
+						Labels: map[string]string{
+							"testlabel": "source-pv",
+						},
+						Annotations: map[string]string{
+							"testannotation": "source-pv",
+						},
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteMany,
+						},
+						Capacity: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+						ClaimRef: &corev1.ObjectReference{
+							APIVersion: "v1",
+							Kind:       "PersistentVolumeClaim",
+							Namespace:  "testns",
+							Name:       "sourcepvc",
+						},
+						PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+						StorageClassName:              sourceScName,
+					},
+					Status: corev1.PersistentVolumeStatus{
+						Phase: corev1.VolumeBound,
+					},
+				},
+				&corev1.PersistentVolume{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "PersistentVolume",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dest-pv",
+						Labels: map[string]string{
+							"testlabel": "dest-pv",
+						},
+						Annotations: map[string]string{
+							"testannotation": "dest-pv",
+						},
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Capacity: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+						ClaimRef: &corev1.ObjectReference{
+							APIVersion: "v1",
+							Kind:       "PersistentVolumeClaim",
+							Namespace:  "testns",
+							Name:       "sourcepvc-pvcmigrate",
+						},
+						PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+						StorageClassName:              sourceScName,
+					},
+					Status: corev1.PersistentVolumeStatus{
+						Phase: corev1.VolumeBound,
+					},
+				},
+			},
+			wantResources: []*metav1.APIResourceList{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset(tt.resources...)
+			testlog := log.New(testWriter{t: t}, "", 0)
+			err := swapPVs(context.Background(), testlog, clientset, tt.ns, tt.pvcName)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantResources, clientset.Resources)
+		})
+	}
+}

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -727,12 +727,13 @@ func Test_swapPVs(t *testing.T) {
 	sourceScName := "sourceScName"
 	destScName := "destScName"
 	tests := []struct {
-		name          string
-		resources     []runtime.Object
-		wantResources []*metav1.APIResourceList
-		ns            string
-		pvcName       string
-		wantErr       bool
+		name      string
+		resources []runtime.Object
+		wantPVs   []corev1.PersistentVolume
+		wantPVCs  []corev1.PersistentVolumeClaim
+		ns        string
+		pvcName   string
+		wantErr   bool
 	}{
 		{
 			name:    "swap one PVC",
@@ -884,7 +885,66 @@ func Test_swapPVs(t *testing.T) {
 					},
 				},
 			},
-			wantResources: []*metav1.APIResourceList{},
+			wantPVs: []corev1.PersistentVolume{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+						Kind:       "PersistentVolume",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "dest-pv",
+						Labels: map[string]string{
+							"testlabel": "dest-pv",
+						},
+						Annotations: map[string]string{
+							desiredReclaimAnnotation: "Delete",
+							sourceNsAnnotation:       "testns",
+							sourcePvcAnnotation:      "sourcepvc",
+							"testannotation":         "dest-pv",
+						},
+					},
+					Spec: corev1.PersistentVolumeSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+						Capacity: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+						PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+						StorageClassName:              sourceScName,
+					},
+					Status: corev1.PersistentVolumeStatus{
+						Phase: corev1.VolumeBound,
+					},
+				},
+			},
+			wantPVCs: []corev1.PersistentVolumeClaim{
+				{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "PersistentVolumeClaim",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "sourcepvc",
+						Namespace: "testns",
+						Labels: map[string]string{
+							"testlabel": "sourcepvc",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteMany,
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+						StorageClassName: &destScName,
+						VolumeName:       "dest-pv",
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -896,9 +956,15 @@ func Test_swapPVs(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-
 			assert.NoError(t, err)
-			assert.Equal(t, tt.wantResources, clientset.Resources)
+
+			finalPVs, err := clientset.CoreV1().PersistentVolumes().List(context.Background(), metav1.ListOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPVs, finalPVs.Items)
+
+			finalPVCs, err := clientset.CoreV1().PersistentVolumeClaims(tt.ns).List(context.Background(), metav1.ListOptions{})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPVCs, finalPVCs.Items)
 		})
 	}
 }


### PR DESCRIPTION
previous logs:
```
Marking previously existing PVs as to-be-retained
Marking PV pvc-3936b6b7-46bd-48a1-86a9-2860469e77f2 as to-be-retained
Marking PV pvc-53b4868f-05c9-4c6e-8a81-49c7c69f6030 as to-be-retained
Marking PV pvc-b45b3d87-0c0e-44ab-9795-55c65f2d3e33 as to-be-retained
Marking PV pvc-dc421d2b-0d11-4a49-8b89-486d7279df98 as to-be-retained

Marking newly-created existing PVs as to-be-retained
Marking PV pvc-b781ebbc-251e-4124-b639-00ce8d341607 (PVC kotsadm-postgres-kotsadm-postgres-0-pvcmigrate in laverya-minimal-kots) as to-be-retained
Marking PV pvc-de30c039-12e1-41fb-8c22-ab4c6ed9fd18 (PVC kotsadm-minio-kotsadm-minio-0-pvcmigrate in another-kots-app) as to-be-retained
Marking PV pvc-e1811dbe-b7d1-4364-b645-e961d05ee3fd (PVC kotsadm-postgres-kotsadm-postgres-0-pvcmigrate in another-kots-app) as to-be-retained
Marking PV pvc-e5e18f6a-ced4-4e50-aa4e-7f59f66d5ab3 (PVC kotsadm-minio-kotsadm-minio-0-pvcmigrate in laverya-minimal-kots) as to-be-retained

Deleting original PVCs to free up names
Deleting original PVC kotsadm-postgres-kotsadm-postgres-0 in another-kots-app
Deleting original PVC kotsadm-minio-kotsadm-minio-0 in another-kots-app
Deleting original PVC kotsadm-postgres-kotsadm-postgres-0 in laverya-minimal-kots
Deleting original PVC kotsadm-minio-kotsadm-minio-0 in laverya-minimal-kots

Deleting migrated-to PVCs to free up PVs
Deleting migrated PVC kotsadm-postgres-kotsadm-postgres-0-pvcmigrate in another-kots-app
Deleting migrated PVC kotsadm-minio-kotsadm-minio-0-pvcmigrate in another-kots-app
Deleting migrated PVC kotsadm-postgres-kotsadm-postgres-0-pvcmigrate in laverya-minimal-kots
Deleting migrated PVC kotsadm-minio-kotsadm-minio-0-pvcmigrate in laverya-minimal-kots

Removing claimrefs from PVs to attach new PVCs
Removing claimrefs from PV pvc-3936b6b7-46bd-48a1-86a9-2860469e77f2
Removing claimrefs from PV pvc-53b4868f-05c9-4c6e-8a81-49c7c69f6030
Removing claimrefs from PV pvc-b45b3d87-0c0e-44ab-9795-55c65f2d3e33
Removing claimrefs from PV pvc-dc421d2b-0d11-4a49-8b89-486d7279df98
Removing claimrefs from PV pvc-b781ebbc-251e-4124-b639-00ce8d341607
Removing claimrefs from PV pvc-de30c039-12e1-41fb-8c22-ab4c6ed9fd18
Removing claimrefs from PV pvc-e1811dbe-b7d1-4364-b645-e961d05ee3fd
Removing claimrefs from PV pvc-e5e18f6a-ced4-4e50-aa4e-7f59f66d5ab3

Creating new PVCs with the original names
Creating PVC kotsadm-postgres-kotsadm-postgres-0 in another-kots-app using PV pvc-e1811dbe-b7d1-4364-b645-e961d05ee3fd
Creating PVC kotsadm-minio-kotsadm-minio-0 in another-kots-app using PV pvc-de30c039-12e1-41fb-8c22-ab4c6ed9fd18
Creating PVC kotsadm-postgres-kotsadm-postgres-0 in laverya-minimal-kots using PV pvc-b781ebbc-251e-4124-b639-00ce8d341607
Creating PVC kotsadm-minio-kotsadm-minio-0 in laverya-minimal-kots using PV pvc-e5e18f6a-ced4-4e50-aa4e-7f59f66d5ab3

Resetting PV retention policies

Scaling back StatefulSets and Deployments with matching PVCs
scaling StatefulSet kotsadm-minio from 0 to 1 in another-kots-app
scaling StatefulSet kotsadm-postgres from 0 to 1 in another-kots-app
scaling StatefulSet kotsadm-minio from 0 to 1 in laverya-minimal-kots
scaling StatefulSet kotsadm-postgres from 0 to 1 in laverya-minimal-kots

Deleting original PVs

Success!
```

new logs:

```
Swapping PVC kotsadm-postgres-kotsadm-postgres-0 in laverya-minimal-kots to the new StorageClass
Marking original PV pvc-b781ebbc-251e-4124-b639-00ce8d341607 as to-be-retained
Marking migrated-to PV pvc-9ee53546-718c-4ee8-8937-c453240c2159 as to-be-retained
Deleting original PVC kotsadm-postgres-kotsadm-postgres-0 in laverya-minimal-kots to free up the name
Deleting migrated-to PVC kotsadm-postgres-kotsadm-postgres-0 in laverya-minimal-kots to release the PV
Removing claimref from original PV pvc-b781ebbc-251e-4124-b639-00ce8d341607
Removing claimref from migrated-to PV pvc-9ee53546-718c-4ee8-8937-c453240c2159
Creating new PVC kotsadm-postgres-kotsadm-postgres-0 with migrated-to PV pvc-9ee53546-718c-4ee8-8937-c453240c2159
Resetting migrated-to PV pvc-9ee53546-718c-4ee8-8937-c453240c2159 reclaim policy
Deleting original, now redundant, PV pvc-b781ebbc-251e-4124-b639-00ce8d341607
Successfully migrated PVC kotsadm-postgres-kotsadm-postgres-0 in laverya-minimal-kots from PV pvc-b781ebbc-251e-4124-b639-00ce8d341607 to pvc-9ee53546-718c-4ee8-8937-c453240c2159

Swapping PVC kotsadm-minio-kotsadm-minio-0 in laverya-minimal-kots to the new StorageClass
Marking original PV pvc-e5e18f6a-ced4-4e50-aa4e-7f59f66d5ab3 as to-be-retained
Marking migrated-to PV pvc-b97edd27-c21f-401e-936a-1b484016788b as to-be-retained
Deleting original PVC kotsadm-minio-kotsadm-minio-0 in laverya-minimal-kots to free up the name
Deleting migrated-to PVC kotsadm-minio-kotsadm-minio-0 in laverya-minimal-kots to release the PV
Removing claimref from original PV pvc-e5e18f6a-ced4-4e50-aa4e-7f59f66d5ab3
Removing claimref from migrated-to PV pvc-b97edd27-c21f-401e-936a-1b484016788b
Creating new PVC kotsadm-minio-kotsadm-minio-0 with migrated-to PV pvc-b97edd27-c21f-401e-936a-1b484016788b
Resetting migrated-to PV pvc-b97edd27-c21f-401e-936a-1b484016788b reclaim policy
Deleting original, now redundant, PV pvc-e5e18f6a-ced4-4e50-aa4e-7f59f66d5ab3
Successfully migrated PVC kotsadm-minio-kotsadm-minio-0 in laverya-minimal-kots from PV pvc-e5e18f6a-ced4-4e50-aa4e-7f59f66d5ab3 to pvc-b97edd27-c21f-401e-936a-1b484016788b

Swapping PVC kotsadm-minio-kotsadm-minio-0 in another-kots-app to the new StorageClass
Marking original PV pvc-de30c039-12e1-41fb-8c22-ab4c6ed9fd18 as to-be-retained
Marking migrated-to PV pvc-ced058b0-c07e-4a8a-abbb-98b7b1f8b50e as to-be-retained
Deleting original PVC kotsadm-minio-kotsadm-minio-0 in another-kots-app to free up the name
Deleting migrated-to PVC kotsadm-minio-kotsadm-minio-0 in another-kots-app to release the PV
Removing claimref from original PV pvc-de30c039-12e1-41fb-8c22-ab4c6ed9fd18
Removing claimref from migrated-to PV pvc-ced058b0-c07e-4a8a-abbb-98b7b1f8b50e
Creating new PVC kotsadm-minio-kotsadm-minio-0 with migrated-to PV pvc-ced058b0-c07e-4a8a-abbb-98b7b1f8b50e
Resetting migrated-to PV pvc-ced058b0-c07e-4a8a-abbb-98b7b1f8b50e reclaim policy
Deleting original, now redundant, PV pvc-de30c039-12e1-41fb-8c22-ab4c6ed9fd18
Successfully migrated PVC kotsadm-minio-kotsadm-minio-0 in another-kots-app from PV pvc-de30c039-12e1-41fb-8c22-ab4c6ed9fd18 to pvc-ced058b0-c07e-4a8a-abbb-98b7b1f8b50e

Swapping PVC kotsadm-postgres-kotsadm-postgres-0 in another-kots-app to the new StorageClass
Marking original PV pvc-e1811dbe-b7d1-4364-b645-e961d05ee3fd as to-be-retained
Marking migrated-to PV pvc-f277e594-f212-4afd-9396-0a7010110071 as to-be-retained
Deleting original PVC kotsadm-postgres-kotsadm-postgres-0 in another-kots-app to free up the name
Deleting migrated-to PVC kotsadm-postgres-kotsadm-postgres-0 in another-kots-app to release the PV
Removing claimref from original PV pvc-e1811dbe-b7d1-4364-b645-e961d05ee3fd
Removing claimref from migrated-to PV pvc-f277e594-f212-4afd-9396-0a7010110071
Creating new PVC kotsadm-postgres-kotsadm-postgres-0 with migrated-to PV pvc-f277e594-f212-4afd-9396-0a7010110071
Resetting migrated-to PV pvc-f277e594-f212-4afd-9396-0a7010110071 reclaim policy
Deleting original, now redundant, PV pvc-e1811dbe-b7d1-4364-b645-e961d05ee3fd
Successfully migrated PVC kotsadm-postgres-kotsadm-postgres-0 in another-kots-app from PV pvc-e1811dbe-b7d1-4364-b645-e961d05ee3fd to pvc-f277e594-f212-4afd-9396-0a7010110071

Scaling back StatefulSets and Deployments with matching PVCs
scaling StatefulSet kotsadm-minio from 0 to 1 in laverya-minimal-kots
scaling StatefulSet kotsadm-postgres from 0 to 1 in laverya-minimal-kots
scaling StatefulSet kotsadm-minio from 0 to 1 in another-kots-app
scaling StatefulSet kotsadm-postgres from 0 to 1 in another-kots-app

Success!
```