### PR TITLE
print sizes when listing PVCs to be migrated

### DIFF
--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -327,10 +327,11 @@ func getPVCs(ctx context.Context, w *log.Logger, clientset k8sclient.Interface, 
 
 	w.Printf("\nFound %d matching PVCs to migrate across %d namespaces:\n", len(matchingPVs), len(matchingPVCs))
 	tw := tabwriter.NewWriter(w.Writer(), 2, 2, 1, ' ', 0)
-	_, _ = fmt.Fprintf(tw, "namespace:\tpvc:\tpv:\t\n")
+	_, _ = fmt.Fprintf(tw, "namespace:\tpvc:\tpv:\tsize:\t\n")
 	for ns, nsPvcs := range matchingPVCs {
 		for _, nsPvc := range nsPvcs {
-			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t\n", ns, nsPvc.Name, nsPvc.Spec.VolumeName)
+			pvCap := pvsByName[nsPvc.Spec.VolumeName].Spec.Capacity
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t\n", ns, nsPvc.Name, nsPvc.Spec.VolumeName, pvCap.Storage().String())
 		}
 	}
 	err = tw.Flush()


### PR DESCRIPTION
new format:
```
Found 4 matching PVCs to migrate across 2 namespaces:
namespace:           pvc:                                pv:                                      size:
another-kots-app     kotsadm-postgres-kotsadm-postgres-0 pvc-758903d5-d053-49c1-8ca9-ef52d1076ed2 1Gi
another-kots-app     kotsadm-minio-kotsadm-minio-0       pvc-dbb9d2c5-7227-47aa-999c-ca42fc4d106c 4Gi
laverya-minimal-kots kotsadm-postgres-kotsadm-postgres-0 pvc-7e3b4338-09ac-46cb-8ca2-63497c24e06d 1Gi
laverya-minimal-kots kotsadm-minio-kotsadm-minio-0       pvc-a5214597-130c-46b3-ae5e-fd77cd8c02d2 4Gi
```