### PR TITLE
fix migration pod's error - chown failed on Operation not permitted (1)

### DIFF
--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -374,6 +374,8 @@ func createMigrationPod(ctx context.Context, clientset k8sclient.Interface, ns s
 						"-a",       // use the "archive" method to copy files recursively with permissions/ownership/etc
 						"-v",       // show verbose output
 						"-P",       // show progress, and resume aborted/partial transfers
+						"--no-o",   // no-owner
+						"--no-g",   // no-group
 						"--delete", // delete files in dest that are not in source
 						"/source/",
 						"/dest",


### PR DESCRIPTION
https://unix.stackexchange.com/questions/12203/rsync-failed-to-set-permissions-on-error-with-rsync-a-or-p-option