### PR TITLE
feat: bails out if rsync pod is silent

### DIFF
--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -3135,9 +3134,8 @@ func Test_readLineWithTimeout(t *testing.T) {
 				return
 			}
 
-			if !reflect.DeepEqual(line, tt.output) {
-				t.Errorf("expected %s, received %s", string(tt.output), string(line))
-			}
+			req := require.New(t)
+			req.Equal(line, tt.output, "expected %q, received %q", string(tt.output), string(line))
 		})
 	}
 }

--- a/pkg/migrate/migrate_test.go
+++ b/pkg/migrate/migrate_test.go
@@ -3118,23 +3118,14 @@ func Test_readLineWithTimeout(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
 			var reader = &mockReader{fn: tt.fn}
 			line, err := readLineWithTimeout(reader, tt.timeout)
-			if err != nil {
-				if len(tt.err) == 0 {
-					t.Errorf("unexpected error: %s", err)
-				} else if !strings.Contains(err.Error(), tt.err) {
-					t.Errorf("expecting %q, %q received instead", tt.err, err)
-				}
-				return
+			if len(tt.err) == 0 {
+				req.NoError(err, "unexpected error %v", err)
+			} else {
+				req.ErrorContains(err, tt.err)
 			}
-
-			if len(tt.err) > 0 {
-				t.Errorf("expecting error %q, nil received instead", tt.err)
-				return
-			}
-
-			req := require.New(t)
 			req.Equal(line, tt.output, "expected %q, received %q", string(tt.output), string(line))
 		})
 	}


### PR DESCRIPTION
if rsync pod does not log anything for 30 minutes we signalize a timeout and bail out the migration.