### PR TITLE
Fix infinity loop caused by SIGINT while waiting for migration Pod to become ready

### DIFF
--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -210,6 +210,12 @@ func copyOnePVC(ctx context.Context, w *log.Logger, clientset k8sclient.Interfac
 	// wait for the pod to be created
 	time.Sleep(waitTime)
 	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context ended waiting for Pod %s in %s to be deleted", createdPod.Name, ns)
+		default:
+		}
+
 		gotPod, err := clientset.CoreV1().Pods(ns).Get(ctx, createdPod.Name, metav1.GetOptions{})
 		if err != nil {
 			w.Printf("failed to get newly created migration pod %s: %v\n", createdPod.Name, err)


### PR DESCRIPTION
Currently, if the user sends a SIGINT (Ctrl+C) to the process while it is waiting for the migration Pod to become Ready, the process will enter an infinity loop, because:

1. It will try to get the Pod from the API Server
2. The client will return an error because the context is expired (due to SIGINT).
3. It will continue to the next iteration of the loop.

This fix, before its iteration checks if the context is Done(), and if so, returns immediately an error to the caller.

Refs https://github.com/replicatedhq/pvmigrate/issues/216. 