### PR TITLE
fix: filter out duplicate pvcs

### DIFF
--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -451,6 +451,21 @@ func getPVCs(ctx context.Context, w *log.Logger, clientset k8sclient.Interface, 
 		}
 	}
 
+	// remove duplicates, ensuring pvcs are unique per namespace
+	for ns, nsPVCs := range matchingPVCs {
+		uniquePVCs := []*corev1.PersistentVolumeClaim{}
+		seen := make(map[string]bool)
+
+		for _, pvc := range nsPVCs {
+			if !seen[pvc.Name] {
+				seen[pvc.Name] = true
+				uniquePVCs = append(uniquePVCs, pvc)
+			}
+		}
+
+		matchingPVCs[ns] = uniquePVCs
+	}
+
 	pvcNamespaces := []string{}
 	for idx := range matchingPVCs {
 		pvcNamespaces = append(pvcNamespaces, idx)

--- a/pkg/migrate/migrate.go
+++ b/pkg/migrate/migrate.go
@@ -466,12 +466,14 @@ func getPVCs(ctx context.Context, w *log.Logger, clientset k8sclient.Interface, 
 		matchingPVCs[ns] = uniquePVCs
 	}
 
+	numPVCs := 0
 	pvcNamespaces := []string{}
 	for idx := range matchingPVCs {
+		numPVCs += len(matchingPVCs[idx])
 		pvcNamespaces = append(pvcNamespaces, idx)
 	}
 
-	w.Printf("\nFound %d matching PVCs to migrate across %d namespaces:\n", len(matchingPVCs), len(pvcNamespaces))
+	w.Printf("\nFound %d matching PVCs to migrate across %d namespaces:\n", numPVCs, len(pvcNamespaces))
 	tw := tabwriter.NewWriter(w.Writer(), 2, 2, 1, ' ', 0)
 	_, _ = fmt.Fprintf(tw, "namespace:\tpvc:\tpv:\tsize:\t\n")
 	for ns, nsPvcs := range matchingPVCs {


### PR DESCRIPTION
Fixes duplicate pvc claimRef leads to failure

```
Found 3 matching PVCs to migrate across 3 namespaces:
namespace: pvc:                                         pv:                                      size: 
default    kotsadm-rqlite-kotsadm-rqlite-0              pvc-11a0eba5-4557-4b4f-8848-82493bc9a70f 1Gi   
default    kotsadm-rqlite-kotsadm-rqlite-2              pvc-260228cd-4539-4365-85b5-fd6dc231b110 1Gi   
default    kotsadm-rqlite-kotsadm-rqlite-1              pvc-3be0eaa5-c487-45b3-867f-67c3d65a7d91 1Gi   
repl       pgdata-repl-postgres-cluster-0              pvc-246fe46a-9c4a-4002-ade4-7f54f717c455 10Gi  
repl       pgdata-repl-postgres-cluster-0              pvc-246fe46a-9c4a-4002-ade4-7f54f717c455 10Gi  
repl       activemq-artemis-instance-activemq-artemis-0 pvc-e7e5e6cc-2694-4053-ac4e-2a6ead2a6e2f 2Gi   
repl       nats-js-nats-0                               pvc-fba0c908-359b-4344-a9a6-f916c9648d2c 10Gi  
monitoring prometheus-k8s-db-prometheus-k8s-0           pvc-452d3527-8aa9-4c37-9f95-9a41fa4f3549 10Gi  
monitoring prometheus-k8s-db-prometheus-k8s-1           pvc-df37f03d-203e-4a49-8e80-1e0fe523a3af 10Gi  
...
Swapping PVC pgdata-repl-postgres-cluster-0 in repl to the new StorageClass
Marking original PV pvc-246fe46a-9c4a-4002-ade4-7f54f717c455 as to-be-retained
Marking migrated-to PV pvc-14b21eb6-71d0-43b1-91c2-d401c32a2a96 as to-be-retained
Deleting original PVC pgdata-repl-postgres-cluster-0 in repl to free up the name
Deleting migrated-to PVC pgdata-repl-postgres-cluster-0-pvcmigrate in repl to release the PV
Waiting for original PVC pgdata-repl-postgres-cluster-0 in repl to finish deleting
Waiting for migrated-to PVC pgdata-repl-postgres-cluster-0-pvcmigrate in repl to finish deleting
Removing claimref from original PV pvc-246fe46a-9c4a-4002-ade4-7f54f717c455
Removing claimref from migrated-to PV pvc-14b21eb6-71d0-43b1-91c2-d401c32a2a96
Creating new PVC pgdata-repl-postgres-cluster-0 with migrated-to PV pvc-14b21eb6-71d0-43b1-91c2-d401c32a2a96
Resetting migrated-to PV pvc-14b21eb6-71d0-43b1-91c2-d401c32a2a96 reclaim policy
Failed to determine new PV pvc-14b21eb6-71d0-43b1-91c2-d401c32a2a96, waiting 5s to retry
Deleting original, now redundant, PV pvc-246fe46a-9c4a-4002-ade4-7f54f717c455
Successfully migrated PVC pgdata-repl-postgres-cluster-0 in repl from PV pvc-246fe46a-9c4a-4002-ade4-7f54f717c455 to pvc-14b21eb6-71d0-43b1-91c2-d401c32a2a96
Swapping PVC pgdata-repl-postgres-cluster-0 in repl to the new StorageClass
migration failed: failed to swap PVs for PVC pgdata-repl-postgres-cluster-0 in repl: failed to get migrated PVC pgdata-repl-postgres-cluster-0-pvcmigrate in repl: persistentvolumeclaims "pgdata-repl-postgres-cluster-0-pvcmigrate" not found
[0;33mAn error occurred on line [0m
```